### PR TITLE
Use django-cleanup to delete files from disk

### DIFF
--- a/liionsden/settings/settings.py
+++ b/liionsden/settings/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "guardian",
+    "django_cleanup.apps.CleanupConfig",  # <-- This must be last
 ]
 
 AUTHENTICATION_BACKENDS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ idutils
 whitenoise
 model_bakery
 django-guardian
+django-cleanup


### PR DESCRIPTION
In the end, the problem was a solved one, as it is often the case. Simply using `django-cleanup` app takes care of getting rid of all the files from disk once the record has been deleted from the DB. 

Close #5 