### PR TITLE
Update publish action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: 
-            - docker.pkg.github.com/imperialcollegelondon/faraday-liionsden/liionsden:${{ github.sha }}
-            - docker.pkg.github.com/imperialcollegelondon/faraday-liionsden/liionsden:latest
+          tags: docker.pkg.github.com/imperialcollegelondon/faraday-liionsden/liionsden:${{ github.sha }}, docker.pkg.github.com/imperialcollegelondon/faraday-liionsden/liionsden:latest
       
       - name: Deploy to Azure Web Apps
         uses: azure/webapps-deploy@v2


### PR DESCRIPTION
The VM is not pulling the 'latest' version of the image. Tagging the image twice when building and pushing, once with the github.sha and once with the docker keyword 'latest'. 