### PR TITLE
Make media available always, not just in DBEUG mode

### DIFF
--- a/liionsden/urls.py
+++ b/liionsden/urls.py
@@ -28,5 +28,4 @@ urlpatterns = [
     path("dfndb/", include("dfndb.urls")),
 ]
 
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
The fix described in https://github.com/ImperialCollegeLondon/Faraday-liionsden/issues/61#issuecomment-1033660741 applied to the `docker-compose.yml` file in the VM made the uploaded files persistent, yet they were not accesible when trying to download them. The reason was that media-related URL were not added to the `urlpatterns` except when in DEBUG mode. This PR changes that - we do want to access files when in production!

Close #61 