### PR TITLE
change parsers to parsing_engines

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 !common
 !dfndb
 !liionsden
-!parsers
+!parsing_engines
 !templates
 !data
 data/db/*


### PR DESCRIPTION
Getting `ModuleNotFoundError: No module named 'parsing_engines'` - fixed by unignoring renamed module. 