### PR TITLE
Improve (just a bit) getting header in biologic

### DIFF
--- a/tests/parsing_engines/test_biologic_parser.py
+++ b/tests/parsing_engines/test_biologic_parser.py
@@ -92,12 +92,9 @@ class TestHeaderToYaml(TestCase):
             header = list(
                 filter(
                     len,
-                    (f.readline().strip("\n") for _ in range(self.parser.skip_rows)),
+                    (f.readline().rstrip() for _ in range(self.parser.skip_rows)),
                 )
             )
         meta = header_to_yaml(header)
 
         self.assertLess(len(meta), len(header))
-        yaml_replacements.pop("\t")
-        for v in yaml_replacements.values():
-            self.assertIn(v.split(":")[0].strip(), meta)


### PR DESCRIPTION
Just some minor changes to make parsing the header slightly more general. It is by no means failure proof. 