### PR TITLE
Add device params and units

### DIFF
--- a/dfndb/initial_parameters.py
+++ b/dfndb/initial_parameters.py
@@ -42,6 +42,50 @@ PARAMETERS = [
     ),
     dict(name="Cycle number", status="Public", symbol="Cyl", unit=("Unitless", "1")),
     dict(name="Record number", status="Public", symbol="Rec", unit=("Unitless", "1")),
+    dict(
+        name="Cell nominal capacity",
+        status="Public",
+        symbol="Q",
+        unit=("Charge", "A·h"),
+    ),
+    dict(name="Form factor", status="Public", symbol="", unit=("Unitless", "1")),
+    dict(name="Anode size", status="Public", symbol="A_{anode}", unit=("Area", "cm^2")),
+    dict(
+        name="Cathode size",
+        status="Public",
+        symbol="A_{cathode}",
+        unit=("Area", "cm^2"),
+    ),
+    dict(
+        name="Anode loading",
+        status="Public",
+        symbol="Q_{anode}",
+        unit=("Areal capacity", "mA·h·cm^{-2}"),
+    ),
+    dict(
+        name="Cathode loading",
+        status="Public",
+        symbol="Q_{cathode}",
+        unit=("Areal capacity", "mA·h·cm^{-2}"),
+    ),
+    dict(
+        name="Number of layers",
+        status="Public",
+        symbol="n_{layers}",
+        unit=("Unitless", "1"),
+    ),
+    dict(
+        name="Electrode coating",
+        status="Public",
+        symbol="coating",
+        unit=("Unitless", "1"),
+    ),
+    dict(
+        name="Electrolyte component",
+        status="Public",
+        symbol="eletrolyte",
+        unit=("Unitless", "1"),
+    ),
 ]
 
 

--- a/dfndb/initial_units.py
+++ b/dfndb/initial_units.py
@@ -76,6 +76,20 @@ SI_QUANTITY_UNITS = [
         unitSymbol="J",
         is_SI_unit=True,
     ),
+    dict(
+        quantityName="Area",
+        quantitySymbol="A",
+        unitName="Metres squared",
+        unitSymbol="m^2",
+        is_SI_unit=True,
+    ),
+    dict(
+        quantityName="Areal capacity",
+        quantitySymbol="Q_A",
+        unitName="Coulombs per meters squared",
+        unitSymbol="C·m^{-2}",
+        is_SI_unit=True,
+    ),
 ]
 
 NOT_SI_QUANTITY_UNITS = [
@@ -110,6 +124,30 @@ NOT_SI_QUANTITY_UNITS = [
         unitSymbol="W·h",
         is_SI_unit=False,
         related_scale=3600,
+    ),
+    dict(
+        quantityName="Length",
+        quantitySymbol="L",
+        unitName="centimetres",
+        unitSymbol="cm",
+        is_SI_unit=False,
+        related_scale=0.01,
+    ),
+    dict(
+        quantityName="Area",
+        quantitySymbol="A",
+        unitName="centimetres squared",
+        unitSymbol="cm^2",
+        is_SI_unit=False,
+        related_scale=0.0001,
+    ),
+    dict(
+        quantityName="Areal capacity",
+        quantitySymbol="Q_A",
+        unitName="milliamps hour per centimetres squared",
+        unitSymbol="mA·h·cm^{-2}",
+        is_SI_unit=False,
+        related_scale=36000,
     ),
 ]
 


### PR DESCRIPTION
Open to suggestions regarding any symbols etc, especially for the unitless parameters such as "number of layers". 

I'd like to get this merged in before updating the VM instance to minimise any confusion from running migrations again.