### PR TITLE
stop saving of invalid EDFs

### DIFF
--- a/battDB/views.py
+++ b/battDB/views.py
@@ -154,6 +154,7 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                 parameters[0].instance.status = obj.status
                 if parameters[0].instance.use_parser:
                     parameters[0].instance.parse = True
+                # If the data file is already uploaded, catch error and delete EDF obj.
                 try:
                     parameters.save()
                     form.instance.full_clean()


### PR DESCRIPTION
Don't save an ExperimentDataFile if the associated HashedFile/UploadedFile violates the unique hash constraint. 

This is handled with a new try/except block in the view so a helpful message can be displayed to the user.

closes #98 