### PR TITLE
migrate to flexible server 

### DIFF
--- a/liionsden/settings/production.py
+++ b/liionsden/settings/production.py
@@ -17,8 +17,10 @@ EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 if os.environ.get("WEBSITE_HOSTNAME") == "liionsden.azurewebsites.net":
     ALLOWED_HOSTS = ["liionsden.azurewebsites.net"]
-    DATABASES["default"]["HOST"] = os.environ["AZURE_POSTGRESQL_HOST"]
-    DATABASES["default"]["USER"] = os.environ["AZURE_POSTGRESQL_USER"]
-    DATABASES["default"]["PASSWORD"] = os.environ["AZURE_POSTGRESQL_PASS"]
-    DATABSES["default"]["NAME"] = os.environ["AZURE_POSTGRESQL_NAME"]
+    DATABASES["default"]["HOST"] = os.environ["AZURE_POSTGRESQL_POSTGRESQL_40DBE_HOST"]
+    DATABASES["default"]["USER"] = os.environ["AZURE_POSTGRESQL_POSTGRESQL_40DBE_USER"]
+    DATABASES["default"]["PASSWORD"] = os.environ[
+        "AZURE_POSTGRESQL_POSTGRESQL_40DBE_PASSWORD"
+    ]
+    DATABSES["default"]["NAME"] = os.environ["AZURE_POSTGRESQL_POSTGRESQL_40DBE_NAME"]
     DATABSES["default"]["OPTIONS"] = {"sslmode": "require"}


### PR DESCRIPTION
Update production.py settings to use the [application settings in the azure app](https://portal.azure.com/#@ImperialLondon.onmicrosoft.com/resource/subscriptions/66765e95-e23e-4157-9b20-a0c921ad15fb/resourceGroups/LiionsdenRG/providers/Microsoft.Web/sites/liionsden/configuration), which are variables passed as environment variables.

The new app settings are for a new Azure Database for PostgreSQL flexible server [liionsden-sql](https://portal.azure.com/#@ImperialLondon.onmicrosoft.com/resource/subscriptions/66765e95-e23e-4157-9b20-a0c921ad15fb/resourceGroups/LiionsdenRG/providers/Microsoft.DBforPostgreSQL/flexibleServers/liionsden-sql/overview). We are required to migrate from a single server to a flexible server, so once we know this works we can decommission the single server ([liionsden-db](https://portal.azure.com/#@ImperialLondon.onmicrosoft.com/resource/subscriptions/66765e95-e23e-4157-9b20-a0c921ad15fb/resourceGroups/LiionsdenRG/providers/Microsoft.DBforPostgreSQL/servers/liionsden-db/overview)). 

closes #160 