### PR TITLE
Dependabot vulnerabilities

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 pandas
 psycopg2-binary
 django_jsoneditor
-Django
+Django>=4.1.2
 djangorestframework
 preparenovonix
 PyYAML

--- a/requirements.in
+++ b/requirements.in
@@ -28,3 +28,4 @@ django-storages[azure]
 django-override-storage
 molmass
 plotly
+oauthlib>=3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ cryptography==37.0.4
     # via azure-storage-blob
 cycler==0.11.0
     # via matplotlib
-django==4.1
+django==4.1.3
     # via
     #   -r requirements.in
     #   crispy-bootstrap5

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,8 +116,10 @@ numpy==1.23.2
     #   matplotlib
     #   pandas
     #   preparenovonix
-oauthlib==3.2.0
-    # via requests-oauthlib
+oauthlib==3.2.2
+    # via
+    #   -r requirements.in
+    #   requests-oauthlib
 openpyxl==3.0.10
     # via -r requirements.in
 packaging==21.3


### PR DESCRIPTION
Update django and oauthlib minor versions to fix two issues identified by dependabot ([1](https://github.com/ImperialCollegeLondon/Faraday-liionsden/security/dependabot/1) and [2](https://github.com/ImperialCollegeLondon/Faraday-liionsden/security/dependabot/2))