### PR TITLE
Azurite url fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,13 @@ jobs:
     needs: qa
 
     runs-on: ubuntu-latest
-
+    env:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_NAME: postgres
+      POSTGRES_HOST: localhost
+      AZURE_STORAGE_CONTAINER: test
+      AZURE_STORAGE_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;
     services:
       postgres:
         image: postgres
@@ -27,7 +33,13 @@ jobs:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite:3.20.1
+        ports:
+          - 10000:10000
+          - 10001:10001
+          - 10002:10002
+        options: --health-cmd "nc -z 127.0.0.1 10000"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
@@ -40,6 +52,8 @@ jobs:
         pip install -r requirements.txt
     - name: Run migrations
       run: python manage.py migrate
+    - name: Create storage container
+      run: python manage.py createstoragecontainer
     - name: Run tests
       env:
         AZURE_STORAGE_ACCOUNT_KEY: '${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}'

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ GitHub.sublime-settings
 # Other excluded
 _other/
 log/
+
+# terraform
+vars.tfvars

--- a/Main.tf
+++ b/Main.tf
@@ -1,0 +1,238 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.24"
+    }
+  }
+  required_version = ">= 1.1.0"
+}
+
+provider "azurerm" {
+  features {}
+}
+
+variable "mode" {
+  type        = string
+  default     = "dev"
+  description = "Instance name e.g. 'dev', 'prod', 'test'."
+}
+variable "image_name" {
+  description = "Full path of the Docker image for the web application."
+  nullable    = false
+}
+variable "image_tag" {
+  description = "Tag of the Docker image for the web application."
+  nullable    = false
+}
+variable "email_password" {
+  sensitive   = true
+  description = "Password for the rcsazbot role account."
+  nullable    = false
+}
+variable "admin_password" {
+  sensitive   = true
+  description = "A secure password for the Django admin user."
+  nullable    = false
+}
+# REVIEW - add any additional secrets/changing config settings as variables
+
+locals {
+  project_name           = "liionsden"                     # REVIEW
+  location               = "ukwest"                        # REVIEW - the azure region to deploy into - https://github.com/claranet/terraform-azurerm-regions/blob/master/REGIONS.md
+  django_settings_module = "liionsden.settings.production" # REVIEW - import path for project's azure settings
+  postgres_admin_login   = "postgres"
+  email_user             = "rcsazbot"
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${local.project_name}-${var.mode}-rg"
+  location = local.location
+}
+
+# Networking
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${local.project_name}-${var.mode}-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = local.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "db" {
+  name                 = "${local.project_name}-${var.mode}-db-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoints    = ["Microsoft.Storage"]
+
+  delegation {
+    name = "fs"
+    service_delegation {
+      name    = "Microsoft.DBforPostgreSQL/flexibleServers"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+resource "azurerm_subnet" "app" {
+  name                 = "${local.project_name}-${var.mode}-app-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+  service_endpoints    = ["Microsoft.Web", "Microsoft.Storage"]
+
+  delegation {
+    name = "webapp"
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_private_dns_zone" "db" {
+  name                = "${var.mode}.${local.project_name}.postgres.database.azure.com"
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "db" {
+  name                  = "${local.project_name}-${var.mode}-database-link"
+  private_dns_zone_name = azurerm_private_dns_zone.db.name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+  resource_group_name   = azurerm_resource_group.rg.name
+}
+
+# Database
+resource "random_password" "db" {
+  length  = 24
+  special = true
+}
+
+resource "azurerm_postgresql_flexible_server" "server" {
+  name                   = "${local.project_name}-${var.mode}-db"
+  resource_group_name    = azurerm_resource_group.rg.name
+  location               = local.location
+  version                = "13" # REVIEW - postgres version - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server#version
+  delegated_subnet_id    = azurerm_subnet.db.id
+  private_dns_zone_id    = azurerm_private_dns_zone.db.id
+  administrator_login    = local.postgres_admin_login
+  administrator_password = random_password.db.result
+  storage_mb             = 2097152           # REVIEW - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server#storage_mb
+  sku_name               = "B_Standard_B1ms" # REVIEW - see https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-compute-storage#compute-tiers-vcores-and-server-types
+  depends_on             = [azurerm_private_dns_zone_virtual_network_link.db]
+}
+
+resource "azurerm_postgresql_flexible_server_database" "db" {
+  name      = local.project_name
+  server_id = azurerm_postgresql_flexible_server.server.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+# File storage
+resource "azurerm_storage_account" "media" {
+  name                      = "${local.project_name}${var.mode}media"
+  resource_group_name       = azurerm_resource_group.rg.name
+  location                  = local.location
+  account_tier              = "Standard" # REVIEW - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#account_tier
+  account_replication_type  = "LRS"      # REVIEW - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#account_replication_type
+  access_tier               = "Hot"      # REVIEW - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#access_tier
+  enable_https_traffic_only = true
+  min_tls_version           = "TLS1_2"
+}
+
+resource "azurerm_storage_container" "media" {
+  name                  = "media"
+  storage_account_name  = azurerm_storage_account.media.name
+  container_access_type = "private"
+}
+
+# Web application
+resource "random_password" "secret_key" {
+  length = 50
+}
+
+resource "azurerm_service_plan" "plan" {
+  name                = "${local.project_name}-${var.mode}-plan"
+  location            = local.location
+  resource_group_name = azurerm_resource_group.rg.name
+  os_type             = "Linux"
+  sku_name            = "B1" # REVIEW - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan#sku_name
+}
+
+resource "azurerm_linux_web_app" "app" {
+  name                      = "${local.project_name}-${var.mode}-app"
+  resource_group_name       = azurerm_resource_group.rg.name
+  location                  = local.location
+  service_plan_id           = azurerm_service_plan.plan.id
+  virtual_network_subnet_id = azurerm_subnet.app.id
+  https_only                = true
+  site_config {
+    application_stack {
+      docker_image     = var.image_name
+      docker_image_tag = var.image_tag
+    }
+    health_check_path                 = "/" # REVIEW - a url path that will return a 200 response
+    health_check_eviction_time_in_min = "2"
+  }
+  app_settings = {
+    # REVIEW - add any extra environment variables for the web app here, these may need to be setup as Terraform variables above
+    POSTGRES_HOST                   = azurerm_postgresql_flexible_server.server.fqdn
+    POSTGRES_USER                   = local.postgres_admin_login
+    POSTGRES_PASSWORD               = random_password.db.result
+    POSTGRES_NAME                   = azurerm_postgresql_flexible_server_database.db.name
+    DJANGO_SETTINGS_MODULE          = local.django_settings_module
+    SECRET_KEY                      = random_password.secret_key.result
+    WEBSITES_PORT                   = 8000
+    EMAIL_USER                      = local.email_user
+    EMAIL_PASSWORD                  = var.email_password
+    ADMIN_PASSWORD                  = var.admin_password
+    AZURE_STORAGE_CONTAINER         = azurerm_storage_container.media.name
+    AZURE_STORAGE_CONNECTION_STRING = azurerm_storage_account.media.primary_connection_string
+  }
+  logs {
+    http_logs {
+      file_system {
+        retention_in_days = 0
+        retention_in_mb   = 35
+      }
+    }
+  }
+}
+
+# Web application logging
+resource "azurerm_log_analytics_workspace" "app" {
+  name                = "${local.project_name}-${var.mode}-analytics"
+  location            = local.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 90
+}
+
+resource "azurerm_monitor_diagnostic_setting" "app" {
+  name                           = "${local.project_name}-${var.mode}-logging"
+  target_resource_id             = azurerm_linux_web_app.app.id
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.app.id
+  log_analytics_destination_type = "Dedicated"
+  log {
+    category = "AppServiceHTTPLogs"
+    enabled  = true
+    retention_policy {
+      enabled = false
+    }
+  }
+  log {
+    category = "AppServiceConsoleLogs"
+    enabled  = true
+    retention_policy {
+      enabled = false
+    }
+  }
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}

--- a/Main.tf
+++ b/Main.tf
@@ -189,6 +189,7 @@ resource "azurerm_linux_web_app" "app" {
     ADMIN_PASSWORD                  = var.admin_password
     AZURE_STORAGE_CONTAINER         = azurerm_storage_container.media.name
     AZURE_STORAGE_CONNECTION_STRING = azurerm_storage_account.media.primary_connection_string
+    AZURE_ACCOUNT_NAME              = azurerm_storage_account.media.name
   }
   logs {
     http_logs {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,15 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.20.1
+    volumes:
+      - azurite:/data
+    healthcheck:
+      test: nc -z 127.0.0.1 10000
+      interval: 5s
+      timeout: 5s
+      retries: 5
   web:
     build: .
     environment:
@@ -24,6 +33,8 @@ services:
       - POSTGRES_NAME=postgres
       - POSTGRES_HOST=db
       - ADMIN_PASSWORD=password
+      - AZURE_STORAGE_CONTAINER=test
+      - AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;
     volumes:
       - .:/usr/src/app
       - ./log:/usr/src/app/log
@@ -33,3 +44,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      azurite:
+        condition: service_healthy
+volumes:
+  azurite:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - azurite:/data
     ports:
       - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
     healthcheck:
       test: nc -z 127.0.0.1 10000
       interval: 5s
@@ -37,7 +39,6 @@ services:
       - ADMIN_PASSWORD=password
       - AZURE_STORAGE_CONTAINER=test
       - AZURE_STORAGE_ACCOUNT_NAME=devstoreaccount1
-      - AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;
     volumes:
       - .:/usr/src/app
       - ./log:/usr/src/app/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_NAME=postgres
       - POSTGRES_HOST=db
+      - ADMIN_PASSWORD=password
     volumes:
       - .:/usr/src/app
       - ./log:/usr/src/app/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     image: mcr.microsoft.com/azure-storage/azurite:3.20.1
     volumes:
       - azurite:/data
+    ports:
+      - "10000:10000"
     healthcheck:
       test: nc -z 127.0.0.1 10000
       interval: 5s
@@ -49,3 +51,4 @@ services:
         condition: service_healthy
 volumes:
   azurite:
+  db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     environment:
       - LOGGING_FILE=/usr/src/app/log/liionsden
       - AZURE_STORAGE_ACCOUNT_KEY
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_NAME=postgres
+      - POSTGRES_HOST=db
     volumes:
       - .:/usr/src/app
       - ./log:/usr/src/app/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - POSTGRES_HOST=db
       - ADMIN_PASSWORD=password
       - AZURE_STORAGE_CONTAINER=test
+      - AZURE_STORAGE_ACCOUNT_NAME=devstoreaccount1
       - AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;
     volumes:
       - .:/usr/src/app

--- a/liionsden/settings/__init__.py
+++ b/liionsden/settings/__init__.py
@@ -1,0 +1,1 @@
+from .settings import *  # noqa: F401, F403

--- a/liionsden/settings/azure.py
+++ b/liionsden/settings/azure.py
@@ -1,0 +1,70 @@
+import logging
+import os
+import sys
+
+from .production import *  # noqa: F401, F403
+
+# configure sending emails from Imperial mail servers
+EMAIL_HOST = "smtp.cc.ic.ac.uk"
+EMAIL_PORT = 465
+EMAIL_USE_SSL = True
+EMAIL_HOST_USER = os.environ["EMAIL_USER"]
+EMAIL_HOST_PASSWORD = os.environ["EMAIL_PASSWORD"]
+SERVER_EMAIL = "rcs-noreply@imperial.ac.uk"
+DEFAULT_FROM_EMAIL = "rcs-noreply@imperial.ac.uk"
+
+# Azure postgres requires connections to be encrypted
+DATABASES["default"]["OPTIONS"].update(dict(sslmode="require"))  # noqa: F405
+
+# Below configuration splits console logging into stdout and stderr (for warnings or
+# worse). This helps the Azure AppServiceConsoleLogs mechanism to distinguish between
+# error and information messages in the log analytics workspace.
+
+
+class InfoFilter(logging.Filter):
+    def filter(self, rec):
+        return rec.levelno in (logging.DEBUG, logging.INFO)
+
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {"format": "{levelname} {asctime} {message}", "style": "{"},
+    },
+    "filters": {
+        "info_filter": {
+            "()": InfoFilter,
+        },
+        "require_debug_false": {
+            "()": "django.utils.log.RequireDebugFalse",
+        },
+    },
+    "handlers": {
+        "console_stdout": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+            "stream": sys.stdout,
+            "level": "DEBUG",
+            "filters": ["info_filter"],
+        },
+        "console_stderr": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+            "stream": sys.stderr,
+            "level": "WARNING",
+        },
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
+        },
+    },
+    "root": {"handlers": ["console_stdout", "console_stderr"]},
+    "loggers": {
+        "django": {
+            "handlers": ["mail_admins"],
+            "level": "INFO",
+        },
+    },
+}

--- a/liionsden/settings/production.py
+++ b/liionsden/settings/production.py
@@ -13,14 +13,3 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SECURE_HSTS_SECONDS = 15552000
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-
-
-if os.environ.get("WEBSITE_HOSTNAME") == "liionsden.azurewebsites.net":
-    ALLOWED_HOSTS = ["liionsden.azurewebsites.net"]
-    DATABASES["default"]["HOST"] = os.environ["AZURE_POSTGRESQL_POSTGRESQL_40DBE_HOST"]
-    DATABASES["default"]["USER"] = os.environ["AZURE_POSTGRESQL_POSTGRESQL_40DBE_USER"]
-    DATABASES["default"]["PASSWORD"] = os.environ[
-        "AZURE_POSTGRESQL_POSTGRESQL_40DBE_PASSWORD"
-    ]
-    DATABASES["default"]["NAME"] = os.environ["AZURE_POSTGRESQL_POSTGRESQL_40DBE_NAME"]
-    DATABASES["default"]["OPTIONS"] = {"sslmode": "require"}

--- a/liionsden/settings/production.py
+++ b/liionsden/settings/production.py
@@ -7,7 +7,7 @@ ALLOWED_HOSTS = ["liionsden.rcs.ic.ac.uk"]
 SECRET_KEY = os.environ["SECRET_KEY"]
 EMAIL_HOST = "smarthost.cc.ic.ac.uk"
 SERVER_EMAIL = "noreply@imperial.ac.uk"
-ADMINS = [("Diego Alonso Álvarez", "d.alonso-alvarez@imperial.ac.uk")]
+ADMINS = [("Daniel Davies", "d.w.davies@imperial.ac.uk")]
 MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/liionsden/settings/settings.py
+++ b/liionsden/settings/settings.py
@@ -186,6 +186,7 @@ if AZURE_CONTAINER and AZURE_CONNECTION_STRING is None:
     # address of the azurite container. This way urls for the storage will work
     # from both the app container and host system.
     import socket
+
     try:
         local_ip = socket.gethostbyname("azurite")
         AZURE_CONNECTION_STRING = f"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://{local_ip}:10000/devstoreaccount1;QueueEndpoint=http://{local_ip}:10001/devstoreaccount1;"  # noqa: E501

--- a/liionsden/settings/settings.py
+++ b/liionsden/settings/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 import tempfile
 
+from azure.core.utils import parse_connection_string
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -175,10 +177,7 @@ LOGOUT_REDIRECT_URL = "/"
 DEFAULT_FILE_STORAGE = "storages.backends.azure_storage.AzureStorage"
 AZURE_CONTAINER = os.getenv("AZURE_STORAGE_CONTAINER")
 AZURE_CONNECTION_STRING = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
-AZURE_ACCOUNT_NAME = "liionsdenmedia"
-# AZURE_ACCOUNT_KEY = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
-AZURE_CUSTOM_DOMAIN = f"{AZURE_ACCOUNT_NAME}.blob.core.windows.net"
-MEDIA_URL = f"https://{AZURE_CUSTOM_DOMAIN}/{AZURE_CONTAINER}/"
+AZURE_ACCOUNT_NAME = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
 
 # Standard local storage for static files
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")

--- a/liionsden/settings/settings.py
+++ b/liionsden/settings/settings.py
@@ -173,9 +173,10 @@ LOGOUT_REDIRECT_URL = "/"
 # File storage
 # Azure blob storage for media files
 DEFAULT_FILE_STORAGE = "storages.backends.azure_storage.AzureStorage"
-AZURE_CONTAINER = "media"
+AZURE_CONTAINER = os.getenv("AZURE_STORAGE_CONTAINER")
+AZURE_CONNECTION_STRING = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
 AZURE_ACCOUNT_NAME = "liionsdenmedia"
-AZURE_ACCOUNT_KEY = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
+# AZURE_ACCOUNT_KEY = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
 AZURE_CUSTOM_DOMAIN = f"{AZURE_ACCOUNT_NAME}.blob.core.windows.net"
 MEDIA_URL = f"https://{AZURE_CUSTOM_DOMAIN}/{AZURE_CONTAINER}/"
 

--- a/liionsden/settings/settings.py
+++ b/liionsden/settings/settings.py
@@ -93,6 +93,7 @@ DATABASES = {
         "PASSWORD": "postgres",
         "HOST": "db",
         "PORT": 5432,
+        "OPTIONS": {},
     },
 }
 

--- a/liionsden/settings/settings.py
+++ b/liionsden/settings/settings.py
@@ -179,6 +179,20 @@ AZURE_CONTAINER = os.getenv("AZURE_STORAGE_CONTAINER")
 AZURE_CONNECTION_STRING = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
 AZURE_ACCOUNT_NAME = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
 
+if AZURE_CONTAINER and AZURE_CONNECTION_STRING is None:
+    # Assume working in docker compose development environment.
+
+    # Try and set the connection string for use with azurite but using the ip
+    # address of the azurite container. This way urls for the storage will work
+    # from both the app container and host system.
+    import socket
+    try:
+        local_ip = socket.gethostbyname("azurite")
+        AZURE_CONNECTION_STRING = f"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://{local_ip}:10000/devstoreaccount1;QueueEndpoint=http://{local_ip}:10001/devstoreaccount1;"  # noqa: E501
+    except socket.gaierror:
+        # ignore if expected hostname is not present
+        pass
+
 # Standard local storage for static files
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 STATIC_URL = "/static/"

--- a/liionsden/urls.py
+++ b/liionsden/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from azure.core.utils import parse_connection_string
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -28,4 +29,7 @@ urlpatterns = [
     path("dfndb/", include("dfndb.urls")),
 ]
 
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns += static(
+    parse_connection_string(settings.AZURE_CONNECTION_STRING)["blobendpoint"],
+    document_root=settings.MEDIA_ROOT,
+)

--- a/management/custom_azure.py
+++ b/management/custom_azure.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from logging import getLogger
 
 from azure.core.exceptions import ResourceNotFoundError
+from azure.core.utils import parse_connection_string
 from azure.storage.blob import BlobServiceClient, generate_blob_sas
 from django.conf import settings
 
@@ -14,7 +15,9 @@ def generate_sas_token(blob_name, permission="r"):
     Generates a SAS token for the Azure storage account.
     Permissions are read only and expiry 1 hour for now.
     """
-    account_key = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
+    account_key = parse_connection_string(settings.AZURE_CONNECTION_STRING)[
+        "accountkey"
+    ]
     azure_container = settings.AZURE_CONTAINER
     sas_token = generate_blob_sas(
         account_name=settings.AZURE_ACCOUNT_NAME,
@@ -33,9 +36,12 @@ def download_blob(local_path="./tmp", blob_name="", sas_token=""):
     Downloads a file from azure and saves it locally given the blob
     name and local file path.
     """
+    blob_endpoint = parse_connection_string(settings.AZURE_CONNECTION_STRING)[
+        "blobendpoint"
+    ]
     try:
         os.makedirs(os.path.join(local_path, "uploaded_files"), exist_ok=True)
-        blob_service_client = BlobServiceClient(settings.AZURE_CUSTOM_DOMAIN, sas_token)
+        blob_service_client = BlobServiceClient(blob_endpoint, sas_token)
         blob_client = blob_service_client.get_container_client(
             container=settings.AZURE_CONTAINER
         )
@@ -56,8 +62,13 @@ def delete_blobs(blob_names, container):
     """
     Deletes the given blobs from the Azure storage account.
     """
-    account_key = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
-    blob_service_client = BlobServiceClient(settings.AZURE_CUSTOM_DOMAIN, account_key)
+    blob_endpoint = parse_connection_string(settings.AZURE_CONNECTION_STRING)[
+        "blobendpoint"
+    ]
+    account_key = parse_connection_string(settings.AZURE_CONNECTION_STRING)[
+        "accountkey"
+    ]
+    blob_service_client = BlobServiceClient(blob_endpoint, account_key)
     blob_client = blob_service_client.get_container_client(container=container)
     for blob_name in blob_names:
         blob_client.delete_blob(blob_name)
@@ -68,7 +79,12 @@ def list_blobs(container):
     """
     Lists all the blobs in the Azure storage account.
     """
-    account_key = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
-    blob_service_client = BlobServiceClient(settings.AZURE_CUSTOM_DOMAIN, account_key)
+    blob_endpoint = parse_connection_string(settings.AZURE_CONNECTION_STRING)[
+        "blobendpoint"
+    ]
+    account_key = parse_connection_string(settings.AZURE_CONNECTION_STRING)[
+        "accountkey"
+    ]
+    blob_service_client = BlobServiceClient(blob_endpoint, account_key)
     blob_client = blob_service_client.get_container_client(container=container)
     return blob_client.list_blobs()

--- a/management/management/commands/createstoragecontainer.py
+++ b/management/management/commands/createstoragecontainer.py
@@ -1,0 +1,31 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Create container in configured Azure blob storage"
+
+    def handle(self, *args, **options):
+        from azure.core.exceptions import ResourceExistsError
+        from azure.storage.blob import BlobServiceClient
+        from django.conf import settings
+
+        if not (settings.AZURE_CONNECTION_STRING and settings.AZURE_CONTAINER):
+            logger.warn("Azure storage settings not configured. Giving up.")
+            return
+
+        blob_service_client = BlobServiceClient.from_connection_string(
+            settings.AZURE_CONNECTION_STRING
+        )
+        container_client = blob_service_client.get_container_client(
+            settings.AZURE_CONTAINER
+        )
+        if not container_client.exists():
+            try:
+                container_client.create_container()
+            except ResourceExistsError:
+                # guard against highly unlikely race condition
+                pass

--- a/management/migrations/0004_add_superuser.py
+++ b/management/migrations/0004_add_superuser.py
@@ -1,0 +1,17 @@
+import os
+
+from django.db import migrations
+
+
+def add_superuser(apps, schema_editor):
+    User = apps.get_model("management", "User")
+    User.objects.create_superuser("admin", password=os.environ["ADMIN_PASSWORD"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("management", "0003_user_institution"),
+    ]
+
+    operations = [migrations.RunPython(add_superuser)]

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -9,4 +9,5 @@ service ssh start
 eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
 
 python manage.py migrate
+python manage.py createstoragecontainer
 python manage.py runserver 0.0.0.0:8000

--- a/tests/battDB/test_views.py
+++ b/tests/battDB/test_views.py
@@ -547,6 +547,7 @@ class DataUploadViewTest(TestCase):
             reverse("battDB:Download File", kwargs={"pk": edf.id})
         )
         self.assertEqual(download_response.status_code, 302)
+        print(download_response.url)
         self.assertTrue(
             download_response.url.startswith(
                 "https://liionsdenmedia.blob.core.windows.net/media/uploaded_files/biologic_example"


### PR DESCRIPTION
Adjusts the docker compose setup for working with Azurite so that storage urls will work from both the app container and the host system. This is useful for local development of Liionsden as file downloads are provided via SAS urls for the end user.

It works by looking up the IP address of the azurite container in `settings.py` and using this within the connection string. The ip address is accessible from both within the Docker network and the host os. One slight drawback is that if the azurite container is recreated it will have a different ip and no longer be accessible but this is unlikely to come up often and can be remedied with a restart of the app container.

Overall its still a bit kludgy but at least it's kludgy in one place in the settings file. It should be possible to push the kludginess totally into the docker compose file but probably the simplest implementation is this one.