### PR TITLE
Add pip-tools to development requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@ In future, this will also be posible via the API.
 
 ## Local installation
 
-If you want to run a local version of Liionsden, we recommend using [Docker](https://www.docker.com/).
+If you want to run a local version of Liionsden, we recommend using [Docker](https://www.docker.com/). A `docker-compose.yml` is provided to include all the required environment variables and containers.
 
 Full instructions to follow once the platform is in production.
 
 ## Development notes
+
+To run Django management commands, you will need to execute them inside the container, ie `docker-compose exec web python manage.py showmigrations`
+
+This container defines the password for the admin user so you can access the admin backend while developing.
 
 ### Contribution guidelines
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In future, this will also be posible via the API.
 ## Local installation
 
 If you want to run a local version of Liionsden, we recommend using [Docker](https://www.docker.com/). A `docker-compose.yml` is provided to include all the required environment variables and containers.
-
+To start the app, run `docker compose up --build`.
 Full instructions to follow once the platform is in production.
 
 ## Development notes

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,3 +4,4 @@ mypy
 isort
 bump2version
 pre-commit
+pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,12 +6,16 @@
 #
 black==22.8.0
     # via -r requirements-dev.in
+build==0.9.0
+    # via pip-tools
 bump2version==1.0.1
     # via -r requirements-dev.in
 cfgv==3.3.1
     # via pre-commit
 click==8.1.3
-    # via black
+    # via
+    #   black
+    #   pip-tools
 distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
@@ -32,8 +36,14 @@ mypy-extensions==0.4.3
     #   mypy
 nodeenv==1.7.0
     # via pre-commit
+packaging==21.3
+    # via build
 pathspec==0.10.0
     # via black
+pep517==0.13.0
+    # via build
+pip-tools==6.10.0
+    # via -r requirements-dev.in
 platformdirs==2.5.2
     # via
     #   black
@@ -44,6 +54,8 @@ pycodestyle==2.9.1
     # via flake8
 pyflakes==2.5.0
     # via flake8
+pyparsing==3.0.9
+    # via packaging
 pyyaml==6.0
     # via pre-commit
 toml==0.10.2
@@ -51,13 +63,18 @@ toml==0.10.2
 tomli==2.0.1
     # via
     #   black
+    #   build
     #   mypy
+    #   pep517
 typing-extensions==4.3.0
     # via
     #   black
     #   mypy
 virtualenv==20.16.4
     # via pre-commit
+wheel==0.38.4
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
Since pip-tools is used to manage requirements, I think it should be included in development requirements.

I also included some notes in the Readme just to help out with getting started with local development.