### PR TITLE
File validation

### DIFF
--- a/battDB/templates/formset.html
+++ b/battDB/templates/formset.html
@@ -13,7 +13,6 @@
                             {{ hidden }}
                         {% endfor %}
                     {% endif %}
-                    {{ field.errors.as_ul }}
                     {{ field|as_crispy_field }}
                 </td>
                 {% endfor %}

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -181,7 +181,11 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                     return render(request, self.template_name, context)
                 # Everything was fine - save and view experiment details page
                 messages.success(request, self.success_message)
-                return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
+                # Redirect to experiment detail view or stay on form if "add another"
+                if "another" in request.POST:
+                    return redirect(request.path_info)
+                else:
+                    return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
         # form or formset is not valid so delete EDF object and return to form
         self.object.delete()
         messages.error(request, "Could not save data file - form not valid.")
@@ -277,9 +281,13 @@ class UpdateDataFileView(PermissionRequiredMixin, UpdateDataInlineView):
                 formset.save()
                 form.instance.full_clean()
 
-            messages.success(request, self.success_message)
-            return redirect("/battDB/exps/{}".format(self.object.experiment.id))
-        messages.error(request, self.failure_message)
+                messages.success(request, self.success_message)
+                # Redirect to experiment detail view or stay on form if "add another"
+                if "another" in request.POST:
+                    return redirect(request.path_info)
+                else:
+                    return redirect("/battDB/exps/{}".format(self.object.experiment.id))
+        messages.error(request, "Could not update information - form not valid.")
         return render(request, self.template_name, context)
 
 

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -167,7 +167,7 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                     if not self.object.ts_data and formset[0].instance.use_parser:
                         messages.error(
                             request,
-                            "Could not parse data file - does it contain data?",
+                            "Could not parse file - is it a valid data file?",
                         )
                         self.object.delete()
                         return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -182,9 +182,8 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                 # Everything was fine - save and view experiment details page
                 messages.success(request, self.success_message)
                 return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
-            # formset is not valid so delete EDF object and return to form
-            else:
-                self.object.delete()
+        # form or formset is not valid so delete EDF object and return to form
+        self.object.delete()
         messages.error(request, "Could not save data file - form not valid.")
         return render(request, self.template_name, context)
 

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -152,6 +152,7 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                 else:
                     obj.status = "private"
                 self.object = form.save()
+
             # Save individual parameters from inline form
             if formset.is_valid():
                 formset.instance = self.object
@@ -178,10 +179,13 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                     )
                     self.object.delete()
                     return render(request, self.template_name, context)
-
-            messages.success(request, self.success_message)
-            return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
-        messages.error(request, request.error)
+                # Everything was fine - save and view experiment details page
+                messages.success(request, self.success_message)
+                return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
+            # formset is not valid so delete EDF object and return to form
+            else:
+                self.object.delete()
+        messages.error(request, "Could not save data file - form not valid.")
         return render(request, self.template_name, context)
 
 

--- a/parsing_engines/biologic_engine.py
+++ b/parsing_engines/biologic_engine.py
@@ -21,6 +21,7 @@ class BiologicParsingEngine(ParsingEngineBase):
         ("text/plain", ".mpt"),
         ("text/plain", ".tsv"),
         ("text/plain", ".txt"),
+        ("text/plain", ".mps"),
     ]
     mandatory_columns: Dict[str, Dict[str, Union[str, Tuple[str, str]]]] = {
         "time/s": dict(symbol="t", unit=("Time", "s")),
@@ -44,10 +45,14 @@ class BiologicParsingEngine(ParsingEngineBase):
         Args:
             file_obj (TextIO): File to parse.
         """
-        skip_rows = get_header_size(file_obj, cls.encoding)
-        if skip_rows == 0:
+        skip_rows, file_type = get_header_size(file_obj, cls.encoding)
+        # check validity of file
+        if file_type in ("invalid", "settings"):
             data = pd.DataFrame([])
             file_metadata = []
+            getLogger().error(
+                f"File {file_obj.name} cannot be parsed: File type: {file_type}."
+            )
         else:
             data = load_biologic_data(file_obj, skip_rows, cls.encoding)
             file_metadata = get_file_header(file_obj, skip_rows, cls.encoding)
@@ -69,6 +74,8 @@ def get_file_header(
         A list of rows for the header, without the termination characters and
         empty lines.
     """
+    if skip_rows == 0:
+        return []
     with file_obj.open("r") as f:
         header = list(filter(len, (f.readline().rstrip() for _ in range(skip_rows))))
         if type(header[0]) == bytes:
@@ -82,7 +89,7 @@ def get_file_header(
     return header
 
 
-def get_header_size(file_obj: TextIO, encoding: str) -> int:
+def get_header_size(file_obj: TextIO, encoding: str) -> Tuple[int, str]:
     """Reads the file and determines the size of the header.
 
     Args:
@@ -90,15 +97,30 @@ def get_header_size(file_obj: TextIO, encoding: str) -> int:
         encoding (str): Encoding of the file.
 
     Returns:
-        Header size as an int
+       Tuple (int, str): The number of rows in the header and a string describing the
+            file format. The str can be "valid", "settings" or "invalid" depending on
+            whether the file is a valid data file, a settings file, or an invalid file.
     """
     file_obj.seek(0)
     with file_obj.open("r") as f:
         lines = iter([i.decode(encoding) for i in f.readlines()])
-        if "ASCII FILE" in next(lines):
-            return int(re.findall(r"[0-9]+", next(lines))[0]) - 1
-        file_obj.seek(0)
-        return 0
+        first_line = next(lines)
+        # Check if the file starts with a line containing the string "ASCII FILE"
+        if "ASCII FILE" in first_line:
+            # Read the next line containing header size, returning it as an int
+            file_obj.seek(0)
+            return (int(re.findall(r"[0-9]+", next(lines))[0]) - 1, "valid")
+        elif "SETTING FILE" in first_line:
+            file_obj.seek(0)
+            return (0, "settings")
+        # If the file does not start with "ASCII FILE", check if there is no header
+        # and the data starts there
+        elif "time/s" in first_line:
+            file_obj.seek(0)
+            return (0, "valid")
+        else:
+            file_obj.seek(0)
+            return (0, "invalid")
 
 
 def load_biologic_data(file_obj: TextIO, skip_rows: int, encoding: str) -> pd.DataFrame:

--- a/tests/parsing_engines/test_biologic_parser.py
+++ b/tests/parsing_engines/test_biologic_parser.py
@@ -20,7 +20,7 @@ class TestBiologicParsingEngine(TestCase):
         from parsing_engines import BiologicParsingEngine as BP
 
         mock_data.return_value = pd.DataFrame()
-        mock_size.return_value = 1
+        mock_size.return_value = (1, "valid")
         mock_head.return_value = {"answer": 42}
 
         file_path = Path(__file__).parent / "biologic_example.csv"
@@ -65,7 +65,7 @@ class TestBiologicFunctions(TestCase):
             lines = iter([i.decode("iso-8859-1") for i in f.readlines()])
             for line in lines:
                 if "Nb header lines" in line:
-                    expected = int(line.strip().split(" ")[-1]) - 1
+                    expected = (int(line.strip().split(" ")[-1]) - 1, "valid")
                     break
 
         self.assertEqual(actual, expected)
@@ -73,7 +73,9 @@ class TestBiologicFunctions(TestCase):
     def test_load_data(self):
         from parsing_engines.biologic_engine import get_header_size, load_biologic_data
 
-        skip_rows = get_header_size(self.parser.file_obj, encoding="iso-8859-1")
+        skip_rows, file_type = get_header_size(
+            self.parser.file_obj, encoding="iso-8859-1"
+        )
 
         actual = load_biologic_data(
             self.parser.file_obj, skip_rows, encoding="iso-8859-1"
@@ -84,7 +86,9 @@ class TestBiologicFunctions(TestCase):
     def test_get_file_header(self):
         from parsing_engines.biologic_engine import get_file_header, get_header_size
 
-        skip_rows = get_header_size(self.parser.file_obj, encoding="iso-8859-1")
+        skip_rows, file_type = get_header_size(
+            self.parser.file_obj, encoding="iso-8859-1"
+        )
 
         header = get_file_header(self.parser.file_obj, skip_rows, encoding="iso-8859-1")
         self.assertGreaterEqual(len(header), 1)


### PR DESCRIPTION
**To be merged after #205**

This fixes the behaviour of the form to upload new data files when the (mime_type , extension) is not valid. 

Previously, the `UploadedFile` was not created because the validator was working correctly, but the associated `ExperimentDataFile` was still created. This caused the associated experiment details page to break entirely. 

With a small fix in the views, the ExperimentDataFile is not created and helpful messages are displayed (see below). 

Files which are now handled correctly: 

- `Group+10+-+Cell+25_02_MB_C03.mpr`: This is a binary file and we should not expect it to be parsed. The extension is not valid so it is caught by the validator. 

closes #190 

![image](https://user-images.githubusercontent.com/5871253/202209175-5c242e2a-74e2-4d5e-8e8d-351ce22eb4d8.png)
