### PR TITLE
Display unparsed datafiles

### DIFF
--- a/battDB/forms.py
+++ b/battDB/forms.py
@@ -343,8 +343,9 @@ class NewExperimentDataFileForm(DataCreateForm):
                 Div(
                     HTML(
                         (
-                            "Upload the raw data file here. Select 'parse' to process "
-                            "the data using your chosen parser. "
+                            "Upload the raw data file here. Select a parser to process "
+                            "the data, or leave blank to upload the file without "
+                            "parsing. "
                         )
                     ),
                     HTML(

--- a/battDB/forms.py
+++ b/battDB/forms.py
@@ -415,6 +415,8 @@ UploadDataFileFormset = inlineformset_factory(
     help_texts={
         "file": None,
     },
+    min_num=1,
+    validate_min=True,
 )
 
 

--- a/battDB/templates/experiment.html
+++ b/battDB/templates/experiment.html
@@ -160,6 +160,11 @@
     </nav>
     <!--Display the actual plots-->
     <div class="tab-content" id="nav-tabContent">
+      {% if not plot_set %}
+        <br>
+        <li class="list-group-item list-group-item-warning">This file was uploaded without being processed. You can still 
+          download the raw data file using the button below.</li>
+      {% endif %}
       {% for plot in plot_set %}
       {% if forloop.first %}
       <div class="tab-pane active show" id="nav-{{forloop.parentloop.counter}}-{{ forloop.counter }}" role="tabpanel"

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -182,9 +182,8 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                 # Everything was fine - save and view experiment details page
                 messages.success(request, self.success_message)
                 return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
-            # formset is not valid so delete EDF object and return to form
-            else:
-                self.object.delete()
+        # form or formset is not valid so delete EDF object and return to form
+        self.object.delete()
         messages.error(request, "Could not save data file - form not valid.")
         return render(request, self.template_name, context)
 

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -152,6 +152,7 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                 else:
                     obj.status = "private"
                 self.object = form.save()
+
             # Save individual parameters from inline form
             if formset.is_valid():
                 formset.instance = self.object
@@ -178,10 +179,13 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                     )
                     self.object.delete()
                     return render(request, self.template_name, context)
-
-            messages.success(request, self.success_message)
-            return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
-        messages.error(request, request.error)
+                # Everything was fine - save and view experiment details page
+                messages.success(request, self.success_message)
+                return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
+            # formset is not valid so delete EDF object and return to form
+            else:
+                self.object.delete()
+        messages.error(request, "Could not save data file - form not valid.")
         return render(request, self.template_name, context)
 
 

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -429,31 +429,36 @@ class ExperimentView(PermissionRequiredMixin, MultiTableMixin, DetailView):
         """
         experiment_plots = []
         for data_file, table in self.get_tables_data().items():
-            edf = self.object.data_files.get(name=data_file)
-            df = DataFrame(table)
-            # generate the plots
-            plots = []
-            parsed_cols = self.get_parsed_col_names(edf, ["Time", "Voltage", "Current"])
-            if parsed_cols:
-                plots.append(
-                    get_html_plot(
-                        df,
-                        x_col=parsed_cols[0],
-                        y_cols=parsed_cols[1:],
-                    )
+            if table:
+                edf = self.object.data_files.get(name=data_file)
+                df = DataFrame(table)
+                # generate the plots
+                plots = []
+                parsed_cols = self.get_parsed_col_names(
+                    edf, ["Time", "Voltage", "Current"]
                 )
-            parsed_cols = self.get_parsed_col_names(
-                edf, ["Time", "Voltage", "Temperature"]
-            )
-            if parsed_cols:
-                plots.append(
-                    get_html_plot(
-                        df,
-                        x_col=parsed_cols[0],
-                        y_cols=parsed_cols[1:],
+                if parsed_cols:
+                    plots.append(
+                        get_html_plot(
+                            df,
+                            x_col=parsed_cols[0],
+                            y_cols=parsed_cols[1:],
+                        )
                     )
+                parsed_cols = self.get_parsed_col_names(
+                    edf, ["Time", "Voltage", "Temperature"]
                 )
-            experiment_plots.append(plots)
+                if parsed_cols:
+                    plots.append(
+                        get_html_plot(
+                            df,
+                            x_col=parsed_cols[0],
+                            y_cols=parsed_cols[1:],
+                        )
+                    )
+                experiment_plots.append(plots)
+            else:
+                experiment_plots.append([])
         return experiment_plots
 
     def get_tables(self):
@@ -467,7 +472,7 @@ class ExperimentView(PermissionRequiredMixin, MultiTableMixin, DetailView):
 
         tables = []
         for data_set, data_file in zip(data, data_files):
-            if data_set:
+            if data[data_set]:
                 tables.append(
                     self.table_class(
                         data_set,

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -425,7 +425,7 @@ class ExperimentView(PermissionRequiredMixin, MultiTableMixin, DetailView):
         For now, it generates two plots if the necessary columns have been parsed:
         - Voltage vs. Current against Time
         - Voltage vs. Temparature against Time
-        Returns a list of these lists.
+        Returns a list of these lists. If there is no table data, returns an empty list.
         """
         experiment_plots = []
         for data_file, table in self.get_tables_data().items():
@@ -465,12 +465,13 @@ class ExperimentView(PermissionRequiredMixin, MultiTableMixin, DetailView):
         """
         Overriding from django_tables2.views.MultiTableMixin to include all columns
         dynamically. This is necessary to ensure that all columns are included in the
-        table.
+        table. The data files are used to determine which columns are available.
+        Returns: list of tables
         """
         data = self.get_tables_data()
         data_files = self.object.data_files.all()
-
         tables = []
+        # Iterate over the data dictionaries and create a table for each
         for data_set, data_file in zip(data, data_files):
             if data[data_set]:
                 tables.append(

--- a/common/models.py
+++ b/common/models.py
@@ -318,6 +318,8 @@ class HashedFile(models.Model):
 
     def clean(self):
         print(self.file.name)
+        if not self.file:
+            raise ValidationError("No file was uploaded.")
         self.hash = hash_file(self.file)
         return super(HashedFile, self).clean()
 


### PR DESCRIPTION
**To be merged after #208** 

This allows the Experiment detail view to be displayed even if one of the data files isn't parsed. Currently the view assumes that for each ExperimentDataFile there will be data to plot. Now it checks that there is before trying to access columns. 

This is a draft PR for now - I would like to tidy up the logic in `battDB.views.ExperimentView`. There are a lot of methods that are used to generate the plots, which could probably be simplified. 

**UPDATE:** This is now ready for review but I expect we can still simplify the views. Interested to see if you have any suggestions @AdrianDAlessandro ...