### PR TITLE
Added .gitattribute file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+#Disables CRLF conversion for .sh files
 *.sh        text eol=lf


### PR DESCRIPTION
Added .gitattribute that excludes .sh files from being converted to CRLF in Windows