### PR TITLE
update cryptography and pillow

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,3 +29,5 @@ django-override-storage
 molmass
 plotly
 oauthlib>=3.2.1
+pillow>=9.3.0
+cryptography>=38.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,10 @@ coreschema==0.0.4
     # via coreapi
 crispy-bootstrap5==0.6
     # via -r requirements.in
-cryptography==37.0.4
-    # via azure-storage-blob
+cryptography==38.0.3
+    # via
+    #   -r requirements.in
+    #   azure-storage-blob
 cycler==0.11.0
     # via matplotlib
 django==4.1.3
@@ -128,8 +130,10 @@ packaging==21.3
     #   matplotlib
 pandas==1.4.4
     # via -r requirements.in
-pillow==9.2.0
-    # via matplotlib
+pillow==9.3.0
+    # via
+    #   -r requirements.in
+    #   matplotlib
 plotly==5.10.0
     # via -r requirements.in
 preparenovonix==1.0.3


### PR DESCRIPTION
To solve dependabot alerts [3](https://github.com/ImperialCollegeLondon/Faraday-liionsden/security/dependabot/3) and [4](https://github.com/ImperialCollegeLondon/Faraday-liionsden/security/dependabot/4).