### PR TITLE
Fix data view

### DIFF
--- a/battDB/views.py
+++ b/battDB/views.py
@@ -186,6 +186,8 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                     return redirect(request.path_info)
                 else:
                     return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
+            # formset not valid so delete EDF object and return to form
+            self.object.delete()
         # form or formset is not valid so return to form
         messages.error(request, "Could not save data file - form not valid.")
         return render(request, self.template_name, context)

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -186,8 +186,7 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                     return redirect(request.path_info)
                 else:
                     return redirect("/battDB/exps/{}".format(self.kwargs.get("pk")))
-        # form or formset is not valid so delete EDF object and return to form
-        self.object.delete()
+        # form or formset is not valid so return to form
         messages.error(request, "Could not save data file - form not valid.")
         return render(request, self.template_name, context)
 

--- a/tests/battDB/test_views.py
+++ b/tests/battDB/test_views.py
@@ -658,9 +658,9 @@ class DataUploadViewTest(TestCase):
             "/accounts/login/",
             {"username": "test_contributor", "password": "contributorpass"},
         )
-
+        # This is invalid because the raw_data_file formset is missing
         post_response = self.client.post(
-            reverse("battDB:New File", kwargs={"pk": self.experiment.id}),
+            reverse("battDB:New File", kwargs={" pk": self.experiment.id}),
             {"name": "Device 4"},
         )
         # Check redirect to correct page

--- a/tests/battDB/test_views.py
+++ b/tests/battDB/test_views.py
@@ -660,8 +660,11 @@ class DataUploadViewTest(TestCase):
         )
         # This is invalid because the raw_data_file formset is missing
         post_response = self.client.post(
-            reverse("battDB:New File", kwargs={" pk": self.experiment.id}),
+            reverse("battDB:New File", kwargs={"pk": self.experiment.id}),
             {"name": "Device 4"},
         )
         # Check redirect to correct page
         self.assertContains(post_response, "Could not save data file - form not valid.")
+        # Check ExperimentDataFile has not been created
+        with self.assertRaises(bdb.ExperimentDataFile.DoesNotExist):
+            bdb.ExperimentDataFile.objects.get(name="Device 4")

--- a/tests/battDB/test_views.py
+++ b/tests/battDB/test_views.py
@@ -647,3 +647,21 @@ class DataUploadViewTest(TestCase):
         self.assertContains(
             get_response, "This file was uploaded without being processed."
         )
+
+    def test_invalid_form(self):
+        import os
+
+        from liionsden.settings import settings
+
+        # Login
+        self.client.post(
+            "/accounts/login/",
+            {"username": "test_contributor", "password": "contributorpass"},
+        )
+
+        post_response = self.client.post(
+            reverse("battDB:New File", kwargs={"pk": self.experiment.id}),
+            {"name": "Device 4"},
+        )
+        # Check redirect to correct page
+        self.assertContains(post_response, "Could not save data file - form not valid.")


### PR DESCRIPTION
Small change to fix the behaviour of the `NewDataFileView` when the **form** is invalid. In this case, `self.object` is not set, so `self.object.delete()` is not necessary and throws an error. 

I discovered this while breaking the view accidentally, so have added a small test that a nice error message is displayed to the user if the form is invalid, rather than raising an exception. 