### PR TITLE
Privacy notice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
     - name: Run tests
       env:
         AZURE_STORAGE_ACCOUNT_KEY: '${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}'
+        PRIVACY_NOTICE_SAS_URL: '${{ secrets.PRIVACY_NOTICE_SAS_URL }}'
       run: python manage.py test
 
   publish:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - AZURE_STORAGE_CONTAINER=test
       - AZURE_STORAGE_ACCOUNT_NAME=devstoreaccount1
       - AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;
+      - PRIVACY_NOTICE_SAS_URL
+
     volumes:
       - .:/usr/src/app
       - ./log:/usr/src/app/log

--- a/liionsden/context_processors.py
+++ b/liionsden/context_processors.py
@@ -1,0 +1,8 @@
+import os
+
+
+def export_vars(request):
+    data = {}
+    data["SETTING_TYPE"] = os.environ["DJANGO_SETTINGS_MODULE"]
+    data["PRIVACY_NOTICE_SAS_URL"] = os.environ["PRIVACY_NOTICE_SAS_URL"]
+    return data

--- a/liionsden/settings/settings.py
+++ b/liionsden/settings/settings.py
@@ -79,6 +79,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "liionsden.context_processors.export_vars",
             ],
         },
     },

--- a/management/templates/registration.html
+++ b/management/templates/registration.html
@@ -10,11 +10,14 @@
     {% csrf_token %}
     {% bootstrap_form form %}
     {% buttons %}
-      <button type="submit" class="btn btn-primary">
-        Submit
-      </button>
+    <button type="submit" class="btn btn-primary">
+      Submit
+    </button>
     {% endbuttons %}
   </form>
+  {% if SETTING_TYPE == "liionsden.settings.azure" %}
+  <p>view our <a href={{PRIVACY_NOTICE_SAS_URL}} target="_blank">privacy
+      notice</a>.</p>
 </div>
-
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
To meet GDPR requirements, a link to the privacy notice has been added. 

This is only needed for the production environment version managed by Imperial College so the privacy notice is stored in azure and the link is only visible on the registration page if liionsden is running in an azure environment. 

The link includes the SAS token to read the privacy notice and must be set as an environment variable within azure. 