### PR TITLE
use environ.get

### DIFF
--- a/liionsden/context_processors.py
+++ b/liionsden/context_processors.py
@@ -4,5 +4,5 @@ import os
 def export_vars(request):
     data = {}
     data["SETTING_TYPE"] = os.environ["DJANGO_SETTINGS_MODULE"]
-    data["PRIVACY_NOTICE_SAS_URL"] = os.environ["PRIVACY_NOTICE_SAS_URL"]
+    data["PRIVACY_NOTICE_SAS_URL"] = os.environ.get("PRIVACY_NOTICE_SAS_URL")
     return data


### PR DESCRIPTION
small fix to use `os.environ.get()` to load the "PRIVACY_NOTICE_SAS_URL" variable. As this variable is only important in production, it doesn't matter that it is `None` when running locally.

This tweak ensures unit tests pass if the environment variable is not set when developing locally. 