### PR TITLE
Do not re-parse data file when editing edf

### DIFF
--- a/battDB/models.py
+++ b/battDB/models.py
@@ -633,7 +633,7 @@ class ExperimentDataFile(cm.BaseModel):
             except UploadedFile.DoesNotExist:
                 self.name = "Unnamed data set"
 
-        if self.file_exists() and self.raw_data_file.parse:
+        if self.file_exists() and self.raw_data_file.parse and not self.is_parsed():
             cols = [
                 c.col_name
                 for c in self.raw_data_file.use_parser.columns.all().order_by("order")


### PR DESCRIPTION
In the end, I think this is the solution to prevent some of the fields from saving when updating an ExperimentDataFile when there is an invalid field. Currently the the EDF is being saved in the `clean()` method after the data is parsed, simply removing that save call lead to some failures in the tests. This PR prevents the file from being parsed if it has already been parsed before, which is fine for updating because the file is not allowed to be updated after it is initially saved.

Close #221