### PR TITLE
Move save() out of clean method for ExperimentDataFile

### DIFF
--- a/battDB/models.py
+++ b/battDB/models.py
@@ -651,11 +651,11 @@ class ExperimentDataFile(cm.BaseModel):
             self.ts_headers = self.parsed_columns()
             self.ts_data = parsed_file["data"]
 
-            # This needs to be reviewed to avoid a recursion loop
-            self.save()
+    def save(self):
+        super(ExperimentDataFile, self).save()
 
-            if self.is_parsed():
-                self.create_ranges()
+        if self.is_parsed():
+            self.create_ranges()
 
     class Meta:
         verbose_name = "Data File"

--- a/battDB/views.py
+++ b/battDB/views.py
@@ -190,6 +190,7 @@ class NewDataFileView(PermissionRequiredMixin, NewDataViewInline):
                     self.object.delete()
                     return render(request, self.template_name, context)
                 # Everything was fine - save and view experiment details page
+                form.instance.save()
                 messages.success(request, self.success_message)
                 # Redirect to experiment detail view or stay on form if "add another"
                 if "another" in request.POST:


### PR DESCRIPTION
The EDF was being saved after the file was parsed in the clean method. This was happening at line 177 in `battDB/views.py` with `form.instance.full_clean()`. 

The `save()` call has been moved out of the `clean` method and is instead called directly in the view after the form and formset are confirmed to be valid.

Close #246 