### PR TITLE
Formset behaviour

### DIFF
--- a/battDB/custom_layout_object.py
+++ b/battDB/custom_layout_object.py
@@ -1,5 +1,4 @@
 from crispy_forms.layout import TEMPLATE_PACK, LayoutObject
-from django.shortcuts import render
 from django.template.loader import render_to_string
 
 

--- a/battDB/forms.py
+++ b/battDB/forms.py
@@ -193,16 +193,20 @@ class NewExperimentForm(DataCreateForm):
                 Column("thermal", css_class="col-3"),
                 Column("external_link", css_class="col-3"),
                 Field("summary"),
-                Fieldset(
-                    "Add devices",
-                    Div(
-                        HTML("Add the device(s) used in this experiment."),
-                        css_class="container pb-4",
-                    ),
-                    Formset("devices"),
-                    required=False,
-                ),
                 Field("notes"),
+                Div(
+                    Fieldset(
+                        "Devices",
+                        HTML(
+                            "Optionally specify the device(s) used in this experiment."
+                        ),
+                        Formset(
+                            "devices",
+                        ),
+                        required=False,
+                    ),
+                    css_class="card bg-light mb-3",
+                ),
                 HTML("<br>"),
                 Field("make_public"),
                 HTML("<br>"),
@@ -223,6 +227,12 @@ class ExperimentDeviceForm(ModelForm):
     class meta:
         model = ExperimentDevice
         exclude = ()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["batch"].initial = None
+        self.fields["batch_sequence"].initial = None
+        self.fields["device_position"].initial = None
 
 
 ExperimentDeviceFormSet = inlineformset_factory(

--- a/battDB/forms.py
+++ b/battDB/forms.py
@@ -233,12 +233,6 @@ class ExperimentDeviceForm(ModelForm):
         model = ExperimentDevice
         exclude = ()
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["batch"].initial = None
-        self.fields["batch_sequence"].initial = None
-        self.fields["device_position"].initial = None
-
 
 ExperimentDeviceFormSet = inlineformset_factory(
     Experiment,

--- a/battDB/forms.py
+++ b/battDB/forms.py
@@ -75,18 +75,23 @@ class NewDeviceForm(DataCreateForm):
                 Column("spec_file", css_class="col-4"),
                 Column("parent", css_class="col-4"),
                 Column("config", css_class="col-4"),
-                HTML("<hr>"),
-                Fieldset(
-                    "Define parameters",
-                    Formset("parameters"),
-                ),
-                HTML("<hr>"),
-                Fieldset(
-                    "Add components",
-                    Formset("components"),
-                ),
-                HTML("<hr>"),
                 Field("notes"),
+                Div(
+                    Fieldset(
+                        "Parameters",
+                        HTML("Optionally specify the parameters of this device"),
+                        Formset("parameters"),
+                    ),
+                    css_class="card bg-light mb-3",
+                ),
+                Div(
+                    Fieldset(
+                        "Components",
+                        HTML("Optionally specify the components of this device"),
+                        Formset("components"),
+                    ),
+                    css_class="card bg-light mb-3",
+                ),
                 HTML("<br>"),
                 Field("make_public"),
                 HTML("<br>"),
@@ -198,7 +203,7 @@ class NewExperimentForm(DataCreateForm):
                     Fieldset(
                         "Devices",
                         HTML(
-                            "Optionally specify the device(s) used in this experiment."
+                            "Optionally specify the device(s) used in this experiment"
                         ),
                         Formset(
                             "devices",

--- a/battDB/models.py
+++ b/battDB/models.py
@@ -716,10 +716,13 @@ class ExperimentDevice(models.Model):
         # raise NotImplementedError
 
     def clean(self):
-        if self.batch is not None and self.batch_sequence > self.batch.batch_size:
-            raise ValidationError("Batch sequence ID cannot exceed batch size!")
-        elif self.batch is not None:
-            Device.objects.get_or_create(batch=self.batch, seq_num=self.batch_sequence)
+        if hasattr(self, "batch"):
+            if self.batch is not None and self.batch_sequence > self.batch.batch_size:
+                raise ValidationError("Batch sequence ID cannot exceed batch size!")
+            elif self.batch is not None:
+                Device.objects.get_or_create(
+                    batch=self.batch, seq_num=self.batch_sequence
+                )
 
     @property
     def user_owner(self):

--- a/battDB/templates/formset.html
+++ b/battDB/templates/formset.html
@@ -1,22 +1,21 @@
-
 {% load crispy_forms_tags %}
 <table width="100%">
-{{ formset.management_form|crispy }}
+    {{ formset.management_form|crispy }}
 
     {% for form in formset.forms %}
-            <tr class="{% cycle 'row1' 'row2' %} formset_row-{{ formset.prefix }}">
-                {% for field in form.visible_fields %}
-                <td class="align-baseline">
-                    {# Include the hidden fields in the form #}
-                    {% if forloop.first %}
-                        {% for hidden in form.hidden_fields %}
-                            {{ hidden }}
-                        {% endfor %}
-                    {% endif %}
-                    {{ field|as_crispy_field }}
-                </td>
-                {% endfor %}
-            </tr>
+    <tr class="{% cycle 'row1' 'row2' %} formset_row-{{ formset.prefix }}">
+        {% for field in form.visible_fields %}
+        <td class="align-baseline">
+            {# Include the hidden fields in the form #}
+            {% if forloop.first %}
+            {% for hidden in form.hidden_fields %}
+            {{ hidden }}
+            {% endfor %}
+            {% endif %}
+            {{ field|as_crispy_field }}
+        </td>
+        {% endfor %}
+    </tr>
     {% endfor %}
 
 </table>
@@ -33,6 +32,6 @@
 
 <style type="text/css">
     td {
-      padding: 0 15px;
+        padding: 0 15px;
     }
-  </style>
+</style>

--- a/common/views.py
+++ b/common/views.py
@@ -171,6 +171,9 @@ class UpdateDataInlineView(UpdateView):
                 if formset.is_valid():
                     formset.instance = self.object
                     formset.save()
+                else:
+                    messages.error(request, self.failure_message)
+                    return render(request, self.template_name, context)
             messages.success(request, self.success_message)
             # Redirect to object detail view or stay on form if "add another"
             if "another" in request.POST:

--- a/common/views.py
+++ b/common/views.py
@@ -88,6 +88,9 @@ class NewDataViewInline(FormView):
                 if formset.is_valid():
                     formset.instance = self.object
                     formset.save()
+                # TODO: Work out why this is breaking the tests so spectacularly
+                # with unexpected EOF on client connection with an open transaction
+                # (and same for update below)
                 else:
                     messages.error(request, self.failure_message)
                     return render(request, self.template_name, context)

--- a/common/views.py
+++ b/common/views.py
@@ -88,6 +88,9 @@ class NewDataViewInline(FormView):
                 if formset.is_valid():
                     formset.instance = self.object
                     formset.save()
+                else:
+                    messages.error(request, self.failure_message)
+                    return render(request, self.template_name, context)
             messages.success(request, self.success_message)
             # Redirect to object detail view or stay on form if "add another"
             if "another" in request.POST:

--- a/common/views.py
+++ b/common/views.py
@@ -90,9 +90,6 @@ class NewDataViewInline(FormView):
                     formset.instance = self.object
                     formset.save()
                 else:
-                    print("XXXXXX")
-                    print(formset.errors)
-                    print(formset.non_form_errors())
                     self.object.delete()
                     formsets_valid = False
                     break

--- a/common/views.py
+++ b/common/views.py
@@ -90,6 +90,9 @@ class NewDataViewInline(FormView):
                     formset.instance = self.object
                     formset.save()
                 else:
+                    print("XXXXXX")
+                    print(formset.errors)
+                    print(formset.non_form_errors())
                     self.object.delete()
                     formsets_valid = False
                     break

--- a/common/views.py
+++ b/common/views.py
@@ -83,23 +83,29 @@ class NewDataViewInline(FormView):
                     obj.status = "private"
                 self.object = form.save()
             # Save individual parameters from inline forms
+            formsets_valid = True
             for key in self.inline_formsets.keys():
                 formset = context[key]
                 if formset.is_valid():
                     formset.instance = self.object
                     formset.save()
-                # TODO: Work out why this is breaking the tests so spectacularly
-                # with unexpected EOF on client connection with an open transaction
-                # (and same for update below)
                 else:
-                    messages.error(request, self.failure_message)
-                    return render(request, self.template_name, context)
-            messages.success(request, self.success_message)
-            # Redirect to object detail view or stay on form if "add another"
-            if "another" in request.POST:
-                return redirect(request.path_info)
-            else:
-                return redirect(self.success_url) if self.success_url else redirect(obj)
+                    self.object.delete()
+                    formsets_valid = False
+                    break
+            # If all inline forms are valid, save instance and redirect
+            if formsets_valid:
+                messages.success(request, self.success_message)
+                # Redirect to object detail view or stay on form if "add another"
+                if "another" in request.POST:
+                    return redirect(request.path_info)
+                else:
+                    return (
+                        redirect(self.success_url)
+                        if self.success_url
+                        else redirect(obj)
+                    )
+        # If form or a formset is not valid, render form with errors
         messages.error(request, self.failure_message)
         return render(request, self.template_name, context)
 
@@ -172,24 +178,28 @@ class UpdateDataInlineView(UpdateView):
                     self.object.status = "private"
                 self.object.save()
             # Save individual parameters from inline form
+            formsets_valid = True
             for key in self.inline_formsets.keys():
                 formset = context[key]
                 if formset.is_valid():
                     formset.instance = self.object
                     formset.save()
                 else:
-                    messages.error(request, self.failure_message)
-                    return render(request, self.template_name, context)
-            messages.success(request, self.success_message)
-            # Redirect to object detail view or stay on form if "add another"
-            if "another" in request.POST:
-                return redirect(request.path_info)
-            else:
-                return (
-                    redirect(self.success_url)
-                    if self.success_url
-                    else redirect(self.object)
-                )
+                    formsets_valid = False
+                    break
+            # If all inline forms are valid, save instance and redirect
+            if formsets_valid:
+                messages.success(request, self.success_message)
+                # Redirect to object detail view or stay on form if "add another"
+                if "another" in request.POST:
+                    return redirect(request.path_info)
+                else:
+                    return (
+                        redirect(self.success_url)
+                        if self.success_url
+                        else redirect(self.object)
+                    )
+        # If form or a formset is not valid, render form with errors
         messages.error(request, self.failure_message)
         return render(request, self.template_name, context)
 

--- a/dfndb/forms.py
+++ b/dfndb/forms.py
@@ -26,7 +26,8 @@ class NewCompoundForm(DataCreateForm):
         model = Compound
         fields = ["name", "formula"]
         help_texts = {
-            "formula": "Chemical formula. This will be used to automatically calculate the mass.",
+            "formula": "Chemical formula. This will be used to automatically calculate "
+            "the mass.",
         }
 
     def __init__(self, *args, **kwargs):
@@ -76,15 +77,18 @@ class NewComponentForm(DataCreateForm):
                 Div(HTML("<h1> Component </h1>")),
                 Column("name", css_class="col-4"),
                 Column("type", css_class="col-4"),
-                Fieldset(
-                    "Composition",
-                    Div(
-                        HTML(
-                            "Optionally specify the amount of each compound in this "
-                            "component. Amounts are relative and unitless."
-                        )
+                Div(
+                    Fieldset(
+                        "Composition",
+                        Div(
+                            HTML(
+                                "Optionally specify the amount of each compound in "
+                                "this component (amounts are relative and unitless)"
+                            )
+                        ),
+                        Formset("composition"),
                     ),
-                    Formset("composition"),
+                    css_class="card bg-light mb-3",
                 ),
                 HTML("<br>"),
                 Field("make_public"),

--- a/tests/battDB/test_views.py
+++ b/tests/battDB/test_views.py
@@ -364,7 +364,7 @@ class CreateExperimentTest(TestCase):
         self.assertEqual(experiment.status, "private")
         self.assertEqual(getattr(experiment, "config").id, form_fields["config"])
         for key, val in form_fields.items():
-            if key != "config":
+            if key not in ["config", "devices-TOTAL_FORMS", "devices-INITIAL_FORMS"]:
                 self.assertEqual(getattr(experiment, key), val)
 
         # Create new experiment with same name - should fail

--- a/tests/battDB/test_views.py
+++ b/tests/battDB/test_views.py
@@ -68,6 +68,10 @@ class CreateDeviceSpecificationTest(TestCase):
                 "abstract": False,
                 "device_type": abstract_device.id,
                 "notes": "Some notes",
+                "deviceparameter_set-INITIAL_FORMS": 0,
+                "deviceparameter_set-TOTAL_FORMS": 0,
+                "devicecomponent_set-INITIAL_FORMS": 0,
+                "devicecomponent_set-TOTAL_FORMS": 0,
             },
         )
         device = bdb.DeviceSpecification.objects.get(name="Actual device")
@@ -86,6 +90,10 @@ class CreateDeviceSpecificationTest(TestCase):
                 "make_public": True,
                 "device_type": abstract_device.id,
                 "notes": "Some other notes",
+                "deviceparameter_set-INITIAL_FORMS": 0,
+                "deviceparameter_set-TOTAL_FORMS": 0,
+                "devicecomponent_set-INITIAL_FORMS": 0,
+                "devicecomponent_set-TOTAL_FORMS": 0,
             },
         )
         self.assertEqual(update_response.status_code, 302)

--- a/tests/battDB/test_views.py
+++ b/tests/battDB/test_views.py
@@ -342,6 +342,8 @@ class CreateExperimentTest(TestCase):
             "thermal": "no",
             "summary": "Not long enough",
             "config": self.device_config.id,
+            "devices-TOTAL_FORMS": 0,
+            "devices-INITIAL_FORMS": 0,
         }
 
         # Invalid Form (short summary)


### PR DESCRIPTION
This addresses the issues identified in #249. 

 > Check that a sensible error/warning message is shown to the user if mandatory fields are missed within a formset.

This has been achieved by more careful handling of formset validation in the views. Form errors display clearly, e.g.: 

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/5871253/211548139-6b467714-7311-4896-b54d-8e1d7885b73d.png">

 > Fix the behaviour of the devices formset within the create/update experiment form.

The clean method of `ExperimentDevice` has been updated to first check for a `batch` attribute so the error isn't thrown if it's absent. 

> Fix the behaviour (silent failure) of the composition formset within the create/update component form.

This was also fixed by more careful formset validation in the views. 

> Fix the appearance / layout of the forms and formsets to make it clear what is mandatory and what is not.

Optional formsets are now in separate grey cards (e.g. below) and always at the bottom of the form to make it more clear that these are separate subsections of the form. It is also now explicitly stated that these sections are optional. I did experiment with a few other options including: 
- Greying out the remaining fields until an option was selected from the first field. e.g. greying out "value" until a "parameter" is selected in the example below. 
- Removing the initial example row (setting `extra=0`) but leaving the "add another" link so the user can add the first then subsequent rows. 

Both solutions proved surprisingly (to me at least) tricky and involved a fair amount of meddling in JavaScript, which caused more problems than it solves. I think the current solution is a fair compromise but I'm open to any suggestions for improvements.  

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/5871253/211549972-a143f197-e458-4745-a065-6dd980063cb9.png">

Finally, view unit tests have been updated to ensure that minimum required management data for the formsets are submitted in post requests.

closes #249 